### PR TITLE
Add PowerShell script to remove Zoom db files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Utilities
+
+## remove-zoom-db-files.ps1
+Use this PowerShell script to delete Zoom data files whose extensions include `db` from the current user's roaming
+AppData directory.
+
+### Usage
+1. Open PowerShell.
+2. Navigate to the folder containing `remove-zoom-db-files.ps1`.
+3. Run the script:
+   ```powershell
+   .\remove-zoom-db-files.ps1
+   ```
+
+The script will report whether the Zoom folder was found and list each file it deletes. Files are removed from
+`$env:APPDATA\Zoom` and matching is limited to extensions that contain `db` (for example `.db`, `.db-wal`, `.db-journal`).

--- a/remove-zoom-db-files.ps1
+++ b/remove-zoom-db-files.ps1
@@ -1,0 +1,31 @@
+<#
+.SYNOPSIS
+Removes Zoom data files whose extensions contain "db" from the user's roaming profile.
+
+.DESCRIPTION
+Locates the Zoom folder inside the current user's roaming AppData directory and deletes any files with
+"db" in their extension (for example .db, .db-wal, .db-journal). Outputs progress messages to indicate
+what was removed and if no matching files are found.
+#>
+
+$zoomPath = Join-Path $env:APPDATA 'Zoom'
+
+if (-not (Test-Path -Path $zoomPath -PathType Container)) {
+    Write-Host "Zoom roaming folder not found at '$zoomPath'. Nothing to clean."
+    exit 0
+}
+
+$targets = Get-ChildItem -Path $zoomPath -File -Recurse |
+    Where-Object { $_.Extension -like '*db*' }
+
+if (-not $targets) {
+    Write-Host "No files with 'db' in the extension were found in '$zoomPath'."
+    exit 0
+}
+
+foreach ($file in $targets) {
+    Write-Host "Deleting $($file.FullName)"
+    Remove-Item -LiteralPath $file.FullName -Force
+}
+
+Write-Host "Deleted $($targets.Count) file(s) with 'db' in the extension from '$zoomPath'."


### PR DESCRIPTION
## Summary
- add a PowerShell utility to delete files with "db" in their extensions from the Zoom roaming folder
- document how to run the cleanup script

## Testing
- not run (not applicable)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692f8d66407483229da3ec1be88c2012)